### PR TITLE
Make register script work when used remote

### DIFF
--- a/pterodactyl_execute.js
+++ b/pterodactyl_execute.js
@@ -67,5 +67,6 @@ if (import.meta.main) {
   configObj.taskTransformer = (f) => {
     return handleTaskExecution(inputdir, outputdir, task, f);
   };
-  const userWorkflow = await import("./" + pkgs);
+  const userWorkflowPath = `file://${Deno.cwd()}/${pkgs}`;
+  const userWorkflow = await import(userWorkflowPath);
 }

--- a/pterodactyl_register.js
+++ b/pterodactyl_register.js
@@ -31,16 +31,25 @@ function generateAllVariables(name, count) {
   return variables;
 }
 
+function getExecutionScript() {
+  if (import.meta.url.startsWith("file://")) {
+    return "pterodactyl_execute.js";
+  }
+  return import.meta.url.split("/").slice(0, -1).join("/") +
+    "/pterodactyl_execute.js";
+}
+
 function generateContainer(pkg, image, taskName) {
   const inputDir = "/var/inputs";
   const outputDir = "/var/outputs";
+
   return {
     image: image,
     args: [
       "run",
       "--allow-read",
       "--allow-write",
-      "pterodactyl_execute.js",
+      getExecutionScript(),
       "--pkgs",
       pkg,
       "--task",

--- a/pterodactyl_register.js
+++ b/pterodactyl_register.js
@@ -313,5 +313,6 @@ if (import.meta.main) {
     handleTaskRegistration(registeredTasks, callsObj, pkgs, image, f);
   configObj.workflowTransformer = (f) =>
     handleWorkflowRegistration(registeredTasks, callsObj, f);
-  const userWorkflow = await import(Deno.cwd() + "/./" + pkgs);
+  const userWorkflowPath = `file://${Deno.cwd()}/${pkgs}`;
+  const userWorkflow = await import(userWorkflowPath);
 }


### PR DESCRIPTION
Register script now works when used from a remote source (github) and also uses the same version/ source location for execution script written into registration json.