### PR TITLE
Remote script example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@ Pterodactyl is a javascript sdk for Flyte
 
 Pterodactyl allows you to author and register flyte workflows in javascript.
 
-Assuming that you have a flyte installation already setup you can follow these steps to get a workflow registered in flyte.
+Assuming that you have a flyte installation already setup you can follow these
+steps to get a workflow registered in flyte.
 
-If you don't already have a flyte installation you can use kind + helm to set up a local kubernetes cluster running flyte. 
+If you don't already have a flyte installation you can use kind + helm to set up
+a local kubernetes cluster running flyte.
 
 #### Create a workflow
 
-Create a workflow using the pterodactyl library in javascript. An example is provided below. Be sure to name it `workflow.js` so the remaining steps work correctly or replace `workflow.js` with your chosen file name in the remaining steps.
+Create a workflow using the pterodactyl library in javascript. An example is
+provided below. Be sure to name it `workflow.js` so the remaining steps work
+correctly or replace `workflow.js` with your chosen file name in the remaining
+steps.
 
 ```javascript
 import {
@@ -35,7 +40,8 @@ const myWorkflow = workflow(function myWorkflow(x, y) {
 
 #### Create a Dockerfile
 
-Create a dockerfile based on a deno image that copies your script into the container. Be sure to name this file `Dockerfile`.
+Create a dockerfile based on a deno image that copies your script into the
+container. Be sure to name this file `Dockerfile`.
 
 ```
 FROM denoland/deno:distroless-1.21.0
@@ -44,7 +50,12 @@ COPY workflow.js workflow.js
 
 #### Build the container image
 
-Using the dockerfile above build the image. Its fine to change the tag provided to docker with `-t` to your prefered tag but you'll need to replace `jsworkflow:v1` in future steps with your chosen tag (you may wish to do this if you have a private container registry to host containers changing the tag to something like: `<private-registry-url>/jsworkflow:v1`). From the directory containing both your javascript workflow and Dockerfile run:
+Using the dockerfile above build the image. Its fine to change the tag provided
+to docker with `-t` to your prefered tag but you'll need to replace
+`jsworkflow:v1` in future steps with your chosen tag (you may wish to do this if
+you have a private container registry to host containers changing the tag to
+something like: `<private-registry-url>/jsworkflow:v1`). From the directory
+containing both your javascript workflow and Dockerfile run:
 
 ```sh
 docker build -t jsworkflow:v1 .
@@ -52,13 +63,18 @@ docker build -t jsworkflow:v1 .
 
 #### Push your container to a registry/load into cluster
 
-This step is very dependent upon how your flyte installation is setup. If you have a private container registry configured pushing the image you created in the last step will provide the best user experience. Assuming that in the last step you tagged your image with your `<private-registry-url>/jsworkflow:v1`, this can be done like:
+This step is very dependent upon how your flyte installation is setup. If you
+have a private container registry configured pushing the image you created in
+the last step will provide the best user experience. Assuming that in the last
+step you tagged your image with your `<private-registry-url>/jsworkflow:v1`,
+this can be done like:
 
 ```sh
 docker push <private-registry>/jsworkflow:v1
 ```
 
-If you're running a local installation using kind you can use the following to load the image into your cluster without deploying a private container registry:
+If you're running a local installation using kind you can use the following to
+load the image into your cluster without deploying a private container registry:
 
 ```sh
 kind load docker-image jsworkflow:v1
@@ -66,7 +82,10 @@ kind load docker-image jsworkflow:v1
 
 #### Register to flyte using pterodactyl_register.js
 
-If the steps above worked correctly then you're ready to register your workflow with flyte. Be sure to replace `localhost:30081` with the endpoint for your flyte installation if it is not also hosted there. Run the following to register with the same version of `pterodactyl` as was used in the example workflow:
+If the steps above worked correctly then you're ready to register your workflow
+with flyte. Be sure to replace `localhost:30081` with the endpoint for your
+flyte installation if it is not also hosted there. Run the following to register
+with the same version of `pterodactyl` as was used in the example workflow:
 
 ```sh
 deno run --allow-read --allow-net https://raw.githubusercontent.com/NotMatthewGriffin/pterodactyl/main/pterodactyl_register.js --pkgs workflow.js --image jsworkflow:v1 --endpoint localhost:30081 --project flytesnacks --domain development --version v1
@@ -74,4 +93,9 @@ deno run --allow-read --allow-net https://raw.githubusercontent.com/NotMatthewGr
 
 #### Run the workflow in flyte console
 
-After all above steps run successfully you can look in your flyte console under the flytesnacks project and development domain to find the workflow `myWorkflow`. At this point it can be run like any other flyte workflow. The flyte console interface will say that the inputs are all of type string but they will be fed to `JSON.parse` and the result of that sent as the argument to your workflow task functions. For this example try 2 for `input0` and 2 for `input1`.
+After all above steps run successfully you can look in your flyte console under
+the flytesnacks project and development domain to find the workflow
+`myWorkflow`. At this point it can be run like any other flyte workflow. The
+flyte console interface will say that the inputs are all of type string but they
+will be fed to `JSON.parse` and the result of that sent as the argument to your
+workflow task functions. For this example try 2 for `input0` and 2 for `input1`.

--- a/examples/readme_example/workflow.js
+++ b/examples/readme_example/workflow.js
@@ -1,7 +1,7 @@
 import {
   task,
   workflow,
-} from "https://raw.githubusercontent.com/NotMatthewGriffin/pterodactyl/remote-script-example/pterodactyl.js";
+} from "https://raw.githubusercontent.com/NotMatthewGriffin/pterodactyl/main/pterodactyl.js";
 
 const sum = task(function sum(x, y) {
   return x + y;

--- a/examples/readme_example/workflow.js
+++ b/examples/readme_example/workflow.js
@@ -1,0 +1,16 @@
+import {
+  task,
+  workflow,
+} from "https://raw.githubusercontent.com/NotMatthewGriffin/pterodactyl/remote-script-example/pterodactyl.js";
+
+const sum = task(function sum(x, y) {
+  return x + y;
+});
+
+const square = task(function square(z) {
+  return z * z;
+});
+
+const myWorkflow = workflow(function myWorkflow(x, y) {
+  return sum(square(x), square(y));
+});

--- a/pterodactyl_execute.js
+++ b/pterodactyl_execute.js
@@ -63,6 +63,6 @@ if (import.meta.main) {
   configObj.taskTransformer = (f) => {
     return handleTaskExecution(inputdir, outputdir, task, f);
   };
-  const userWorkflowPath = `file://${Deno.cwd()}/${pkgs}`;
+  const userWorkflowPath = pkgs.startsWith('https://') || pkgs.startsWith('http://') ? pkgs : `file://${Deno.cwd()}/${pkgs}`;
   const userWorkflow = await import(userWorkflowPath);
 }

--- a/pterodactyl_execute.js
+++ b/pterodactyl_execute.js
@@ -63,6 +63,9 @@ if (import.meta.main) {
   configObj.taskTransformer = (f) => {
     return handleTaskExecution(inputdir, outputdir, task, f);
   };
-  const userWorkflowPath = pkgs.startsWith('https://') || pkgs.startsWith('http://') ? pkgs : `file://${Deno.cwd()}/${pkgs}`;
+  const userWorkflowPath =
+    pkgs.startsWith("https://") || pkgs.startsWith("http://")
+      ? pkgs
+      : `file://${Deno.cwd()}/${pkgs}`;
   const userWorkflow = await import(userWorkflowPath);
 }

--- a/pterodactyl_register.js
+++ b/pterodactyl_register.js
@@ -415,7 +415,7 @@ if (import.meta.main) {
       version,
       f,
     );
-  const userWorkflowPath = `file://${Deno.cwd()}/${pkgs}`;
+  const userWorkflowPath = pkgs.startsWith('https://') || pkgs.startsWith('http://') ? pkgs : `file://${Deno.cwd()}/${pkgs}`;
   const userWorkflow = await import(userWorkflowPath);
   // User workflow has been imported; upload
   await uploadTasks(endpoint, Object.values(registeredObjs.tasks));

--- a/pterodactyl_register.js
+++ b/pterodactyl_register.js
@@ -45,6 +45,7 @@ function generateContainer(pkg, image, taskName) {
       "run",
       "--allow-read",
       "--allow-write",
+      "--allow-net",
       getExecutionScript(),
       "--pkgs",
       pkg,

--- a/pterodactyl_register.js
+++ b/pterodactyl_register.js
@@ -343,6 +343,7 @@ async function uploadToFlyte(endpoint, type, objs) {
   let jsonResults = await Promise.all(registrationResults.map((result) => {
     return result.json();
   }));
+  console.log(jsonResults);
   console.log(`Registered ${type}`);
 }
 
@@ -415,7 +416,10 @@ if (import.meta.main) {
       version,
       f,
     );
-  const userWorkflowPath = pkgs.startsWith('https://') || pkgs.startsWith('http://') ? pkgs : `file://${Deno.cwd()}/${pkgs}`;
+  const userWorkflowPath =
+    pkgs.startsWith("https://") || pkgs.startsWith("http://")
+      ? pkgs
+      : `file://${Deno.cwd()}/${pkgs}`;
   const userWorkflow = await import(userWorkflowPath);
   // User workflow has been imported; upload
   await uploadTasks(endpoint, Object.values(registeredObjs.tasks));

--- a/pterodactyl_register.js
+++ b/pterodactyl_register.js
@@ -344,7 +344,6 @@ async function uploadToFlyte(endpoint, type, objs) {
   let jsonResults = await Promise.all(registrationResults.map((result) => {
     return result.json();
   }));
-  console.log(jsonResults);
   console.log(`Registered ${type}`);
 }
 


### PR DESCRIPTION
- Adds the example workflow from the readme as a separate file so that it can be registered with its url.
- Allow remote scripts to be used as workflows (requires --allow-net on register and execute)
- Format repo

