### PR TITLE
Launch plan reference

### DIFF
--- a/pterodactyl.js
+++ b/pterodactyl.js
@@ -5,6 +5,10 @@ globalThis.pterodactylConfig = globalThis.pterodactylConfig ?? {
     () => {
       throw "taskReference can't be used locally";
     },
+  launchPlanReferenceTransformer: ({ project, domain, name, version }) =>
+    () => {
+      throw "launchPlanReference can't be used locally";
+    },
 };
 
 export function task(func, options = {}) {
@@ -26,6 +30,18 @@ export function taskReference({ project, domain, name, version }) {
   });
 }
 
+export function launchPlanReference({ project, domain, name, version }) {
+  if (!(project && domain && name && version)) {
+    throw "launchPlanReference must recieve project, domain, name, and version";
+  }
+  return window.pterodactylConfig.launchPlanReferenceTransformer({
+    project,
+    domain,
+    name,
+    version,
+  });
+}
+
 export function workflow(func, options = {}) {
   if (typeof (func) !== "function") {
     throw "workflow must recieve a function";
@@ -36,6 +52,7 @@ export function workflow(func, options = {}) {
 const pterodactyl = {
   task: task,
   taskReference: taskReference,
+  launchPlanReference: launchPlanReference,
   workflow: workflow,
 };
 


### PR DESCRIPTION
Adds Launch Plan References to pterodactyl. Using a Launch plan reference allows workflows to call other already registered workflows by their launch plan similar to how a task reference can be used to call an existing task.