### PR TITLE
Register multiple workflows in single script

### DIFF
--- a/pterodactyl_register.js
+++ b/pterodactyl_register.js
@@ -149,7 +149,7 @@ function convertToTask(
         metadata: {
           runtime: {
             type: "OTHER",
-            version: "0.0.3",
+            version: "0.0.4",
             flavor: "pterodactyl",
           },
           retries: {},

--- a/pterodactyl_register.js
+++ b/pterodactyl_register.js
@@ -429,6 +429,11 @@ async function convertToWorkflow(
     });
   }
 
+  // ensure no properties are set on the callsObj
+  for (let prop of Object.keys(callsObj)) {
+    delete callsObj[prop];
+  }
+
   // make workflow function consistently async
   const consistentFunc = f instanceof AsyncFunction
     ? f


### PR DESCRIPTION
Clears the callsObj before attempting to trace input and output through task calls in a workflow. This allows multiple workflows to be registered from the same script at once without the calls of either workflow interfering with the other.