### PR TITLE
Register multiple workflows at once with their correct call graph.

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -806,8 +806,8 @@ export async function registerScriptWithOptions(
     endpoint,
     registeredObjs.launchPlanReferences,
   );
-  await Promise.all(workflowsSeen.map(([workflow, options]) => {
-    return handleWorkflowRegistration(
+  for (let [workflow, options] of workflowsSeen) {
+    await handleWorkflowRegistration(
       registeredObjs,
       callsObj,
       project,
@@ -816,7 +816,7 @@ export async function registerScriptWithOptions(
       workflow,
       options,
     );
-  }));
+  }
   // User workflow has been imported; upload
   await uploadTasks(endpoint, Object.values(registeredObjs.tasks));
   await uploadWorkflows(


### PR DESCRIPTION
Fix bug which caused workflows to be registered based on another workflows call graph.