### PR TITLE
Pterodactyl Tasks called by reference can use named arguments

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -2,6 +2,21 @@ import * as _ from "./pterodactyl.js";
 
 const AsyncFunction = (async () => {}).constructor;
 
+export function isSerializable(value) {
+  const isPlainObj = Object.getPrototypeOf(value) == Object.getPrototypeOf({});
+  if (isPlainObj) {
+    return Object.values(value).every(isSerializable);
+  }
+
+  const isArray = Array.isArray(value);
+  if (isArray) {
+    return value.every(isSerializable);
+  }
+
+  return typeof value === "string" ||
+    typeof value === "boolean" || typeof value === "number";
+}
+
 class PromiseBinding {
   constructor({ promiseNodeId, outputName }) {
     this.promiseNodeId = promiseNodeId;

--- a/src/register.js
+++ b/src/register.js
@@ -199,7 +199,7 @@ function convertToTask(
         metadata: {
           runtime: {
             type: "OTHER",
-            version: "0.0.6",
+            version: "0.0.7",
             flavor: "pterodactyl",
           },
           retries: {},

--- a/src/register.js
+++ b/src/register.js
@@ -2,6 +2,13 @@ import * as _ from "./pterodactyl.js";
 
 const AsyncFunction = (async () => {}).constructor;
 
+class PromiseBinding {
+  constructor ({promiseNodeId, outputName}) {
+    this.promiseNodeId = promiseNodeId;
+    this.outputName = outputName;
+  }
+}
+
 function getNameFromFunction(f) {
   if (!f.name) {
     throw "Functions must be named";
@@ -218,8 +225,7 @@ function inputCaptureObj(registeredObjs, callsObj, name, isAsync) {
       if (arg instanceof Promise) {
         throw "Tasks cannot take Promises as input";
       }
-      const { promiseNodeId, outputName } = arg;
-      if (!promiseNodeId || !outputName) {
+      if (!(arg instanceof PromiseBinding)) {
         throw `Argument for parameter ${paramName} of task ${name} is not a task output or workflow input`;
       }
       passedArguments.push([paramName, arg]);
@@ -228,10 +234,10 @@ function inputCaptureObj(registeredObjs, callsObj, name, isAsync) {
       callsObj[name] = [];
     }
     callsObj[name].push(passedArguments);
-    return {
+    return new PromiseBinding({
       promiseNodeId: `${name}-${callsObj[name].length - 1}`,
       outputName: getOutputNameFromTask(reference),
-    };
+    });
   };
   if (isAsync) {
     return async (...args) => captureObj(...args);
@@ -273,10 +279,9 @@ function taskReferenceInputCaptureObj(registeredObjs, callsObj, name) {
         if (arg instanceof Promise) {
           throw "Tasks cannot take Promises as input";
         }
-        const { promiseNodeId, outputName } = arg;
-        if (!promiseNodeId || !outputName) {
+	if (!(arg instanceof PromiseBinding)) {
           throw `Argument for parameter ${paramName} of task reference ${name} is not a task output or workflow input`;
-        }
+	}
         passedArguments.push([paramName, arg]);
       }
     } else {
@@ -303,10 +308,10 @@ function taskReferenceInputCaptureObj(registeredObjs, callsObj, name) {
         if (arg instanceof Promise) {
           throw "Tasks cannot take Promises as input";
         }
-        const { promiseNodeId, outputName } = arg;
-        if (!promiseNodeId || !outputName) {
+	if (!(arg instanceof PromiseBinding)) {
           throw `Argument for parameter ${paramName} of task reference ${name} is not a task output or workflow input`;
-        }
+	}
+        
         passedArguments.push([paramName, arg]);
       }
     }
@@ -314,10 +319,10 @@ function taskReferenceInputCaptureObj(registeredObjs, callsObj, name) {
       callsObj[name] = [];
     }
     callsObj[name].push(passedArguments);
-    return {
+    return new PromiseBinding({
       promiseNodeId: `${name}-${callsObj[name].length - 1}`,
       outputName: getOutputNameFromTask(reference),
-    };
+    });
   };
 }
 
@@ -346,8 +351,7 @@ function launchPlanReferenceInputCaptureObj(registeredObjs, callsObj, name) {
       if (arg instanceof Promise) {
         throw "Launch Plans cannot take Promises as input";
       }
-      const { promiseNodeId, outputName } = arg;
-      if (!promiseNodeId || !outputName) {
+      if (!(arg instanceof PromiseBinding)) {
         throw `Argument for parameter ${paramName} of launch plan reference ${name} is not a task output or workflow input`;
       }
       passedArguments.push([paramName, arg]);
@@ -356,10 +360,10 @@ function launchPlanReferenceInputCaptureObj(registeredObjs, callsObj, name) {
       callsObj[name] = [];
     }
     callsObj[name].push(passedArguments);
-    return {
+    return new PromiseBinding({
       promiseNodeId: `${name}-${callsObj[name].length - 1}`,
       outputName: getOutputNameFromLaunchPlan(reference),
-    };
+    });
   };
 }
 
@@ -422,10 +426,10 @@ async function convertToWorkflow(
 
   const inputs = [];
   for (let i = 0; i < inputCount; i++) {
-    inputs.push({
+    inputs.push(new PromiseBinding({
       promiseNodeId: "start-node",
       outputName: options?.paramNames ? options?.paramNames[i] : `input${i}`,
-    });
+    }));
   }
 
   // ensure no properties are set on the callsObj

--- a/src/register.js
+++ b/src/register.js
@@ -441,12 +441,13 @@ async function convertToWorkflow(
   const consistentFunc = f instanceof AsyncFunction
     ? f
     : async (...inputs) => f(...inputs);
-  const { promiseNodeId, outputName } = await consistentFunc(
+  const result = await consistentFunc(
     ...inputs,
   );
-  if (!promiseNodeId || !outputName) {
+  if (!(result instanceof PromiseBinding)) {
     throw `Workflow ${workflowName} output is not task output or workflow input`;
   }
+  const { promiseNodeId, outputName } = result;
 
   const taskNodes = [];
   for (let [nodeName, calls] of Object.entries(callsObj)) {

--- a/test-cases/references/namedArgumentTaskReferenceWorkflow.js
+++ b/test-cases/references/namedArgumentTaskReferenceWorkflow.js
@@ -1,0 +1,12 @@
+import { taskReference, workflow } from "../../pterodactyl.js";
+
+const taskRef = taskReference({
+  project: "flytesnacks",
+  domain: "development",
+  version: "v1",
+  name: "sum",
+});
+
+const testcase = workflow(function usesTaskReferenceNamedArgument(a, b) {
+  return taskRef({ input0: a, input1: b });
+});

--- a/test-cases/references/referencesZeroArgumentTask.js
+++ b/test-cases/references/referencesZeroArgumentTask.js
@@ -1,0 +1,12 @@
+import { taskReference, workflow } from "../../pterodactyl.js";
+
+const taskRef = taskReference({
+  project: "flytesnacks",
+  domain: "development",
+  version: "v1",
+  name: "noArgs",
+});
+
+const testcase = workflow(function usesNoArgsTaskReference() {
+  return taskRef();
+});

--- a/test-cases/references/zeroArgumentTask.js
+++ b/test-cases/references/zeroArgumentTask.js
@@ -1,0 +1,9 @@
+import pterodactyl from "../../pterodactyl.js";
+
+const zeroArgumentTask = pterodactyl.task(function noArgs() {
+  return 0;
+});
+
+const zeroArgumentWorkflow = pterodactyl.workflow(function noArgs() {
+  return zeroArgumentTask();
+});

--- a/test.js
+++ b/test.js
@@ -164,6 +164,19 @@ Deno.test("pterodactyl tests", async (t) => {
         "Failed to register workflow with task reference",
       );
     });
+
+    await t.step("Register workflow using task reference with named arguments", async (t) => {
+      await expectRegisterSuccess(
+	"./test-cases/references/namedArgumentTaskReferenceWorkflow.js",
+        "denoland/deno:distroless-1.24.1",
+        [
+          'Registered {"resource_type":"WORKFLOW","project":"flytesnacks","domain":"development","name":"usesTaskReferenceNamedArgument","version":"v1"}',
+          'Registered {"resource_type":"LAUNCH_PLAN","project":"flytesnacks","domain":"development","name":"usesTaskReferenceNamedArgument","version":"v1"}',
+          "",
+        ].join("\n"),
+        "Failed to register workflow with task reference",
+      );
+    });
   });
 
   // Fail to register with constant inputs

--- a/test.js
+++ b/test.js
@@ -139,6 +139,18 @@ Deno.test("pterodactyl tests", async (t) => {
       "Failed to register referenced workflow",
     );
 
+    await expectRegisterSuccess(
+      "./test-cases/references/zeroArgumentTask.js",
+      "denoland/deno:distroless-1.24.1",
+      [
+        'Registered {"resource_type":"TASK","project":"flytesnacks","domain":"development","name":"noArgs","version":"v1"}',
+        'Registered {"resource_type":"WORKFLOW","project":"flytesnacks","domain":"development","name":"noArgs","version":"v1"}',
+        'Registered {"resource_type":"LAUNCH_PLAN","project":"flytesnacks","domain":"development","name":"noArgs","version":"v1"}',
+        "",
+      ].join("\n"),
+      "Failed to register referenced workflow",
+    );
+
     await t.step("Register workflow using launch plan reference", async (t) => {
       await expectRegisterSuccess(
         "./test-cases/references/launchPlanWorkflow.js",
@@ -159,6 +171,19 @@ Deno.test("pterodactyl tests", async (t) => {
         [
           'Registered {"resource_type":"WORKFLOW","project":"flytesnacks","domain":"development","name":"usesTaskReference","version":"v1"}',
           'Registered {"resource_type":"LAUNCH_PLAN","project":"flytesnacks","domain":"development","name":"usesTaskReference","version":"v1"}',
+          "",
+        ].join("\n"),
+        "Failed to register workflow with task reference",
+      );
+    });
+
+    await t.step("Register workflow using zero argument task reference", async (t) => {
+      await expectRegisterSuccess(
+        "./test-cases/references/referencesZeroArgumentTask.js",
+        "denoland/deno:distroless-1.24.1",
+        [
+          'Registered {"resource_type":"WORKFLOW","project":"flytesnacks","domain":"development","name":"usesNoArgsTaskReference","version":"v1"}',
+          'Registered {"resource_type":"LAUNCH_PLAN","project":"flytesnacks","domain":"development","name":"usesNoArgsTaskReference","version":"v1"}',
           "",
         ].join("\n"),
         "Failed to register workflow with task reference",

--- a/test.js
+++ b/test.js
@@ -6,6 +6,10 @@ import {
   assertEquals,
 } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 
+import {
+  isSerializable
+} from "./src/register.js";
+
 const basicRegistrationCmd = [
   "deno",
   "run",
@@ -21,6 +25,48 @@ const basicRegistrationCmd = [
   "--version",
   "v1",
 ];
+
+Deno.test("isSerializable test", async (t) => {
+  class TestClass{
+    constructor(x) {
+      this.x = x;
+    }
+  }
+
+  await t.step("String is serializable", async (t) => {
+    assert(isSerializable("hello world"), "String is not serializable");
+  });
+
+  await t.step("Boolean is serializable", async (t) => {
+    assert(isSerializable(true), "Boolean is not serializable");
+    assert(isSerializable(false), "Boolean is not serializable");
+  });
+
+  await t.step("Number is serializable", async (t) => {
+    assert(isSerializable(false), "Number is not serializable");
+  });
+
+  await t.step("Array is serializable", async (t) => {
+    assert(isSerializable([1, "hi", false]), "Array is not serializable");
+  });
+
+  await t.step("Plain object is serializable", async (t) => {
+    assert(isSerializable({x: 10}), "Plain object not serializable");
+  });
+
+  await t.step("Class is not serializable", async (t) => {
+    assert(!isSerializable(new TestClass(10)), "class is serializable");
+  });
+
+  await t.step("Class nested in array is not serializable", async (t) => {
+    assert(!isSerializable([new TestClass(10)]), "class is serializable");
+  });
+
+
+  await t.step("Class nested in object is not serializable", async (t) => {
+    assert(!isSerializable({x:new TestClass(10)}), "class is serializable");
+  });
+});
 
 Deno.test("pterodactyl tests", async (t) => {
   // Start cluster for testing


### PR DESCRIPTION
When using a task reference to a pterodactyl task it can now be called using key word arguments as a normal task reference would be called in flyte. The task reference can still be called with positional arguments as before.